### PR TITLE
chore: install agent skills + Makefile lifecycle targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 !README.md
 !LICENSE
 !AGENTS.md
+!skills-lock.json
 !.cursorrules
 !.github/
 !.github/**

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ STOW      := stow
 STOW_DIR  := $(shell pwd)
 TARGET    := $(HOME)
 
-.PHONY: help install uninstall restow dry-run lint check fix doctor hooks update submodules antigen-update skip-worktree sync-workspace sync-workspace-dry-run update-repos bootstrap-arch bootstrap-manjaro bootstrap-ubuntu bootstrap-ubuntu-windows bootstrap-mac bootstrap-work uninstall-arch uninstall-manjaro uninstall-ubuntu uninstall-mac uninstall-work
+.PHONY: help install uninstall restow dry-run lint check fix doctor hooks update submodules antigen-update skip-worktree sync-workspace sync-workspace-dry-run update-repos bootstrap-arch bootstrap-manjaro bootstrap-ubuntu bootstrap-ubuntu-windows bootstrap-mac bootstrap-work uninstall-arch uninstall-manjaro uninstall-ubuntu uninstall-mac uninstall-work skills-list skills-update skills-restore
 
 .DEFAULT_GOAL := help
 
@@ -95,6 +95,20 @@ skip-worktree: ## Ignore runtime changes to volatile config files (run once afte
 	@echo "skip-worktree applied to:"
 	@for f in $(SKIP_WORKTREE_FILES); do echo "  $$f"; done
 	@echo "To commit a real settings change: git update-index --no-skip-worktree <file>"
+
+##@ Skills
+
+skills-list: ## List project skills installed via skills-lock.json
+	@npx skills list -p
+
+skills-update: ## Update project skills and show what changed
+	@npx skills update -p -y
+	@echo ""
+	@echo "Changed skill files:"
+	@git diff --name-only -- .agents/skills skills-lock.json || true
+
+skills-restore: ## Download/restore pinned skills from skills-lock.json
+	@npx skills experimental_install
 
 ##@ Workspace integration (cuberhaus multi-root)
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "bash-defensive-patterns": {
+      "source": "wshobson/agents",
+      "sourceType": "github",
+      "skillPath": "plugins/shell-scripting/skills/bash-defensive-patterns/SKILL.md",
+      "computedHash": "9c63659b9130b214b75f84ec11ac715b647250ca8e0cde2357f4c578d43cfc24"
+    },
+    "shellcheck-configuration": {
+      "source": "wshobson/agents",
+      "sourceType": "github",
+      "skillPath": "plugins/shell-scripting/skills/shellcheck-configuration/SKILL.md",
+      "computedHash": "cb87c1d9fc44443a3ebe53432cf4077ae1e9daa46dfe73d140ae777b853f8592"
+    }
+  }
+}


### PR DESCRIPTION
Adds 1 agent skill via the `skills` CLI (lockfile in `skills-lock.json`):

- `wshobson/agents@bash-defensive-patterns` (Low Risk)

Also adds:
- `skills-list` / `skills-update` / `skills-restore` targets to the existing Makefile
- Whitelists `skills-lock.json` in the whitelist .gitignore (`.agents/` stays naturally ignored)

After clone, run `make skills-restore` to populate `.agents/skills/`.